### PR TITLE
fix compile error "/usr/bin/ld: cannot find -lreadline"

### DIFF
--- a/scripts/install_pg_repack.sh
+++ b/scripts/install_pg_repack.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-apt-get install -y make unzip gcc libssl-dev zlib1g-dev
+apt-get install -y make unzip gcc libssl-dev zlib1g-dev libreadline-dev
 wget -q -O pg_repack.zip "https://api.pgxn.org/dist/pg_repack/1.4.6/pg_repack-1.4.6.zip"
 unzip pg_repack.zip && rm pg_repack.zip
 cd pg_repack-*
 make && make install
 cd ..
 rm -rf pg_repack-*
-apt-get remove --auto-remove -y make unzip gcc libssl-dev zlib1g-dev
+apt-get remove --auto-remove -y make unzip gcc libssl-dev zlib1g-dev libreadline-dev


### PR DESCRIPTION
Adds `libreadline-dev` for pg_repack compile.

Here's the error I was getting before.

```
/usr/bin/ld: cannot find -lreadline
collect2: error: ld returned 1 exit status
make[1]: *** [/usr/lib/postgresql/13/lib/pgxs/src/makefiles/pgxs.mk:462: pg_repack] Error 1
make[1]: Leaving directory '/pg_repack-1.4.6/bin'
make: *** [Makefile:35: all] Error 2
```